### PR TITLE
Fix Typo in init.py (utf8 -> UTF8)

### DIFF
--- a/package/__init__.py
+++ b/package/__init__.py
@@ -153,7 +153,7 @@ class Selection(object):
 			data = content[L_UNICODE]
 			if data:
 				try:
-					return data.decode(utf8)
+					return data.decode(UTF8)
 				except UnicodeDecodeError:
 					return None
 			else:


### PR DESCRIPTION
This fixes presumably a typo that prevented klembord from running get_text() on Linux for me